### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/Net/Curl.pm6
+++ b/lib/Net/Curl.pm6
@@ -1,7 +1,7 @@
 
 use v6;
 
-module Net::Curl;
+unit module Net::Curl;
 
 use NativeCall;
 


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.
