### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,5 +1,6 @@
 {
   "name"        : "Net::Curl",
+  "license"     : "MIT",
   "version"     : "0.1.0",
   "perl"        : "6.c",
   "description" : "Perl 6 interface to libcurl, the free and easy-to-use client-side URL transfer library",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license